### PR TITLE
fixed qtwidget.newimage to actually accept tensors.

### DIFF
--- a/packages/qtwidget/init.lua
+++ b/packages/qtwidget/init.lua
@@ -255,7 +255,7 @@ function newimage(...)
    setmetatable(self, imageClass)
    local firstarg = ...
    if (G.package.loaded['torch'] and G.package.loaded['libqttorch'] and
-       G.torch.typename(firstarg) == "torch.Tensor") then
+       G.torch.type(firstarg):find('torch%..+Tensor')) then
       self.port = qt.QtLuaPainter(qt.QImage.fromTensor(firstarg))
    else
       self.port = qt.QtLuaPainter(...)


### PR DESCRIPTION
The following fails in the current master..

```
require 'qt'
require 'qttorch'
require 'qtwidget'
require 'qtuiloader'
qim = qtwidget.newimage(image.lena())
```

Because torch.typename(image.lena()) does not equal `'torch.Tensor'`, but whatever the default tensor type is (ie `'torch.DoubleTensor'`).  This is fixed now.
