### PR TITLE
CMake defines _WIN32, not WIN32

### DIFF
--- a/qtlua/qtluautils.h
+++ b/qtlua/qtluautils.h
@@ -9,7 +9,7 @@ extern "C" {
 }
 #include "qtluaconf.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 # ifdef libqtlua_EXPORTS
 #  define QTLUAAPI __declspec(dllexport)
 # else

--- a/qtutil/qtutilconf.h
+++ b/qtutil/qtutilconf.h
@@ -3,7 +3,7 @@
 #ifndef QTUTILCONF_H
 #define QTUTILCONF_H
 
-#ifdef WIN32
+#ifdef _WIN32
 # ifdef libqtutil_EXPORTS
 #  define QTUTILAPI __declspec(dllexport)
 # else


### PR DESCRIPTION
This makes things compile and work under Windows with CMake.