### PR TITLE
Update qtwidget.cpp

### DIFF
--- a/packages/qtwidget/qtwidget.cpp
+++ b/packages/qtwidget/qtwidget.cpp
@@ -38,8 +38,8 @@
 static QMetaEnum 
 f_enumerator(const char *s, const QMetaObject *mo)
 {
-  int index = mo->indexOfEnumerator(s);
-  if (mo >= 0)
+  int index = (mo) ? mo->indexOfEnumerator(s) : -1;
+  if (index >= 0)
     return mo->enumerator(index);
   return QMetaEnum();
 }


### PR DESCRIPTION
Fix following building error.
Tested on MacOS 10.13.5 with Clang 6.0.
---------
[ 95%] Building CXX object packages/qtwidget/CMakeFiles/libqtwidget.dir/qtwidget.cpp.o
/tmp/luarocks_qtlua-scm-1-8425/qtlua/packages/qtwidget/qtwidget.cpp:42:10: error: ordered comparison between pointer and zero
      ('const QMetaObject *' and 'int')
  if (mo >= 0)
      ~~ ^  ~
1 error generated.
make[2]: *** [packages/qtwidget/CMakeFiles/libqtwidget.dir/qtwidget.cpp.o] Error 1
make[1]: *** [packages/qtwidget/CMakeFiles/libqtwidget.dir/all] Error 2
make: *** [all] Error 2


